### PR TITLE
Travis CI + coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,91 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+.venv/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+
+# Use container-based infrastructure
+sudo: false
+
+python:
+ - pypy
+ - pypy3
+ - 2.7
+ - 3.5
+ - 2.6
+ - 3.3
+ - 3.4
+
+install:
+ - python setup.py install
+ - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
+
+script:
+ - nosetests --with-warnaserror tests/test_*.py
+
+after_script:
+ - pip install pep8 pyflakes
+ - pyflakes . | tee >(wc -l)
+ - pep8 --statistics --count .
+
+matrix:
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,21 +15,21 @@ python:
 install:
  - python setup.py install
  - pip install coverage
+ - pip install pep8
+ - pip install pyflakes
  - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
 
 script:
  - coverage run --include=warnaserror.py -m nose -vx tests/test_*.py
+ - pyflakes .
+ - pep8 --statistics --count .
 
 after_success:
     # Report coverage and send to coveralls.io
   - pip install coveralls
   - coverage report
   - coveralls
-
-after_script:
- - pip install pep8 pyflakes
- - pyflakes . | tee >(wc -l)
- - pep8 --statistics --count .
+  - pyflakes .
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,17 @@ python:
 
 install:
  - python setup.py install
+ - pip install coverage
  - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
 
 script:
- - nosetests --with-warnaserror tests/test_*.py
+ - coverage run --include=warnaserror.py -m nose -vx tests/test_*.py
+
+after_success:
+    # Report coverage and send to coveralls.io
+  - pip install coveralls
+  - coverage report
+  - coveralls
 
 after_script:
  - pip install pep8 pyflakes

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ setup(
     name='warnaserror',
     author='Bernhard Thiel',
     license="MIT",
-    py_modules = ['warnaserror'],
-    version = '0.01',
-    entry_points = {
+    py_modules=['warnaserror'],
+    version='0.01',
+    entry_points={
         'nose.plugins.0.10': [
             'warnaserror = warnaserror:WarnAsError'
             ]

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""
+Fake test
+"""
+from __future__ import print_function, unicode_literals
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+
+class TestFake(unittest.TestCase):
+
+    def test_fake(self):
+        # Just to check the option can be called with
+        # nosetests for different Python versions.
+        self.assertTrue(True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/warnaserror.py
+++ b/warnaserror.py
@@ -1,11 +1,13 @@
-__author__ = 'Bernhard Thiel'
-
 from nose.plugins import Plugin
 import warnings
+
+__author__ = 'Bernhard Thiel'
+
 
 class WarnAsError(Plugin):
     """Treat warnings that occur DURIONG tests as errors."""
     enabled = False
+
     def options(self, parser, env):
         """
         Add options to command line.
@@ -18,7 +20,6 @@ class WarnAsError(Plugin):
         """
         super(WarnAsError, self).configure(options, conf)
 
-
     def prepareTestRunner(self, runner):
         """
         Treat warnings as errors.
@@ -26,13 +27,12 @@ class WarnAsError(Plugin):
         return WaETestRunner(runner)
 
 
-
 class WaETestRunner(object):
+
     def __init__(self, runner):
-        self.runner=runner
+        self.runner = runner
+
     def run(self, test):
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             return self.runner.run(test)
-
-

--- a/warnaserror.py
+++ b/warnaserror.py
@@ -1,7 +1,6 @@
 __author__ = 'Bernhard Thiel'
 
 from nose.plugins import Plugin
-import nose
 import warnings
 
 class WarnAsError(Plugin):


### PR DESCRIPTION
Dummy unit test just to check nosetests runs with the option on different Python versions.

You'll get reports like this:
https://travis-ci.org/hugovk/WarnAsError/builds/183070250
https://coveralls.io/builds/9228488

Enable Travis CI and Coveralls at https://travis-ci.org/profile and https://coveralls.io/repos/new both are free for open source.

Also fix pyflakes and pep8 and allow them to fail builds.