### PR TITLE
Add Python 3.6, drop unsupported 2.6, 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ python:
  - pypy
  - pypy3
  - 2.7
+ - 3.6
  - 3.5
- - 2.6
- - 3.3
  - 3.4
 
 install:
@@ -17,7 +16,6 @@ install:
  - pip install coverage
  - pip install pep8
  - pip install pyflakes
- - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
 
 script:
  - coverage run --include=warnaserror.py -m nose -vx tests/test_*.py

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -4,10 +4,7 @@ Fake test
 """
 from __future__ import print_function, unicode_literals
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 
 class TestFake(unittest.TestCase):

--- a/warnaserror.py
+++ b/warnaserror.py
@@ -5,7 +5,7 @@ __author__ = 'Bernhard Thiel'
 
 
 class WarnAsError(Plugin):
-    """Treat warnings that occur DURIONG tests as errors."""
+    """Treat warnings that occur DURING tests as errors."""
     enabled = False
 
     def options(self, parser, env):


### PR DESCRIPTION
## Reasons for dropping old ones

* https://en.wikipedia.org/wiki/CPython#Version_history

### 2.6

* https://snarky.ca/stop-using-python-2-6/
* http://www.curiousefficiency.org/posts/2015/04/stop-supporting-python26.html
* Current pip 9 deprecates Python 2.6 support, pip 10 won't support it (https://github.com/pypa/pip/issues/3955)
* Not much PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796

### 3.3

* pip 10 will deprecate Python 3.3 support, pip 11 won't support it (https://github.com/pypa/pip/issues/3796)
* Very little PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796
