### PR TITLE
Adds selecting which warning to turn into error

### DIFF
--- a/warnaserror.py
+++ b/warnaserror.py
@@ -14,25 +14,42 @@ class WarnAsError(Plugin):
         """
         super(WarnAsError, self).options(parser, env)
 
+        parser.add_option(
+            str('--warning-class'), action='store', dest='warning_class',
+            default=None,
+            help="Set the warning class to turn into an error. Default: all warnings"
+        )
+
     def configure(self, options, conf):
         """
         Configure plugin.
         """
         super(WarnAsError, self).configure(options, conf)
+        self.options = options
 
     def prepareTestRunner(self, runner):
         """
         Treat warnings as errors.
         """
-        return WaETestRunner(runner)
+        return WaETestRunner(runner, self.options.warning_class)
 
 
 class WaETestRunner(object):
 
-    def __init__(self, runner):
+    def __init__(self, runner, warning_class=None):
         self.runner = runner
+        self.warning_class = warning_class
 
     def run(self, test):
+        warning_class = Warning
+        if self.warning_class:
+            if '.' in self.warning_class:
+                path, obj = self.warning_class.rsplit('.', 1)
+            else:
+                path = 'builtins'
+                obj = self.warning_class
+            import importlib
+            warning_class = getattr(importlib.import_module(path), obj)
         with warnings.catch_warnings():
-            warnings.simplefilter("error")
+            warnings.simplefilter("error", category=warning_class)
             return self.runner.run(test)


### PR DESCRIPTION
This is helpful when you only want a particular class of warnings to be turned
into errors.

If the warning of interest is one of the standard python ones
(https://docs.python.org/3.1/library/warnings.html) you can pass to nosetests
only the warning class name, eg: `--warning-class=Warning`

For anything else provide the full Python path:
`--warning-class=package.module.CustomWarning`